### PR TITLE
Fix the build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,75 +2,220 @@
 name = "pwong"
 version = "0.0.1"
 dependencies = [
- "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "sdl2 0.2.3 (git+https://github.com/AngryLawyer/rust-sdl2)",
- "time 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sdl2 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitflags"
-version = "0.1.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "gcc"
-version = "0.3.5"
+name = "gl"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gl_generator 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gl_generator"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "khronos_api 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "khronos_api"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.1.7"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num"
-version = "0.1.24"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.3.8"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-serialize"
-version = "0.3.14"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sdl2"
-version = "0.2.3"
-source = "git+https://github.com/AngryLawyer/rust-sdl2#f270e9879cd91324a3adc7c0367971e7cda27b9c"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sdl2-sys 0.2.2 (git+https://github.com/AngryLawyer/rust-sdl2)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sdl2-sys 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sdl2-sys"
-version = "0.2.2"
-source = "git+https://github.com/AngryLawyer/rust-sdl2#f270e9879cd91324a3adc7c0367971e7cda27b9c"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.25"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "xml-rs"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum gl 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8923b27373830338b9e6ee7cb07940711eaff56ea308055ae2add63c1443eb3e"
+"checksum gl_generator 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0940975a4ca12b088d32b5d5134826c47d2e73de4b0b459b05244c01503eccbb"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum khronos_api 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d5a08e2a31d665af8f1ca437eab6d00a93c9d62a549f73f9ed8fc2e55b5a91a7"
+"checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
+"checksum libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e7eb6b826bfc1fdea7935d46556250d1799b7fe2d9f7951071f4291710665e3e"
+"checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
+"checksum num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "98b15ba84e910ea7a1973bccd3df7b31ae282bf9d8bd2897779950c9b8303d40"
+"checksum num-bigint 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ba6d838b16e56da1b6c383d065ff1ec3c7d7797f65a3e8f6ba7092fd87820bac"
+"checksum num-complex 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "148eb324ca772230853418731ffdf13531738b50f89b30692a01fcdcb0a64677"
+"checksum num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "ef1a4bf6f9174aa5783a9b4cc892cacd11aebad6c69ad027a0b65c6ca5f8aa37"
+"checksum num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d1891bd7b936f12349b7d1403761c8a0b85a18b148e9da4429d5d102c1a41e"
+"checksum num-rational 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "c2dc5ea04020a8f18318ae485c751f8cfa1c0e69dcf465c29ddaaa64a313cc44"
+"checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
+"checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
+"checksum redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "29dbdfd4b9df8ab31dec47c6087b7b13cbf4a776f335e4de8efba8288dda075b"
+"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum sdl2 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63066036ad426250ac56d23e38fd05063b38b661556acd596f4046cc92d98415"
+"checksum sdl2-sys 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b48638b7882759f3421038fcd38ad5f1ea19b119d80c99f1601933004629e34d"
+"checksum time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd7ccbf969a892bf83f1e441126968a07a3941c24ff522a26af9f9f4585d1a3"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum xml-rs 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7ec6c39eaa68382c8e31e35239402c0a9489d4141a8ceb0c716099a0b515b562"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,8 @@ path = "src/lib.rs"
 name = "main"
 path = "src/main.rs"
 
-[dependencies.sdl2]
-git = "https://github.com/AngryLawyer/rust-sdl2"
-
 [dependencies]
 time = "*"
 num = "*"
+sdl2 = "0.30"
+gl = "0.6.0"

--- a/src/entities/game.rs
+++ b/src/entities/game.rs
@@ -141,17 +141,25 @@ impl Game {
     pub fn move_objects(&mut self) {
         if !self.paused {
             let p1_key = self.keymap.last_pressed(&[Keycode::A, Keycode::Z]);
-            self.players[0].direction = match p1_key {
-                Keycode::A => PaddleDirection::UP,
-                Keycode::Z => PaddleDirection::DOWN,
-                _ => PaddleDirection::NONE,
-            };
+
+            if p1_key.is_some() {
+                self.players[0].direction = match p1_key.unwrap() {
+                    Keycode::A => PaddleDirection::UP,
+                    Keycode::Z => PaddleDirection::DOWN,
+                    _ => PaddleDirection::NONE,
+                };
+            }
+
             let p2_key = self.keymap.last_pressed(&[Keycode::Quote, Keycode::Slash]);
-            self.players[1].direction = match p2_key {
-                Keycode::Quote => PaddleDirection::UP,
-                Keycode::Slash => PaddleDirection::DOWN,
-                _ => PaddleDirection::NONE,
-            };
+
+            if p2_key.is_some() {
+                self.players[1].direction = match p2_key.unwrap() {
+                    Keycode::Quote => PaddleDirection::UP,
+                    Keycode::Slash => PaddleDirection::DOWN,
+                    _ => PaddleDirection::NONE,
+                };
+            }
+
             for player in self.players.iter_mut() {
                 player.update()
             }

--- a/src/entities/game.rs
+++ b/src/entities/game.rs
@@ -1,25 +1,34 @@
 extern crate sdl2;
+extern crate gl;
 
 use super::keymap::KeyPressMap;
 use super::paddle::{Paddle, PaddleDirection};
 use super::court::Court;
 use super::ball::Ball;
 
-use self::sdl2::sdl::Sdl;
-use self::sdl2::keycode::KeyCode;
-use self::sdl2::event::{Event, EventPump, WindowEventId};
-use self::sdl2::video::{Window, WindowPos, RESIZABLE};
-use self::sdl2::render::{RenderDriverIndex, SOFTWARE, Renderer};
+use self::sdl2::EventPump;
+use self::sdl2::keyboard::Keycode;
+use self::sdl2::event::{Event, WindowEvent};
+use self::sdl2::video::{Window, WindowPos};
+use self::sdl2::render::Canvas;
 use self::sdl2::pixels::Color;
 
 use std::thread;
 
-static PADDLE_WIDTH : i32 = 40;
-static PADDLE_HEIGHT : i32 = 100;
-static BALL_RADIUS : i32 = 15;
-static INITIAL_BALL_VX : i32 = -4;
-static INITIAL_BALL_VY : i32 = 0;
+static PADDLE_WIDTH: i32 = 40;
+static PADDLE_HEIGHT: i32 = 100;
+static BALL_RADIUS: i32 = 15;
+static INITIAL_BALL_VX: i32 = -4;
+static INITIAL_BALL_VY: i32 = 0;
 
+fn find_sdl_gl_driver() -> Option<u32> {
+    for (index, item) in sdl2::render::drivers().enumerate() {
+        if item.name == "opengl" {
+            return Some(index as u32);
+        }
+    }
+    None
+}
 
 pub struct Game {
     running: bool,
@@ -37,37 +46,56 @@ impl Game {
         let court = Court::new(width, height);
         let paddle_y = height / 2 - PADDLE_HEIGHT / 2;
         let p1 = Paddle::new(0, paddle_y, height, PADDLE_WIDTH, PADDLE_HEIGHT);
-        let p2 = Paddle::new(width - PADDLE_WIDTH, paddle_y, height, PADDLE_WIDTH, PADDLE_HEIGHT);
+        let p2 = Paddle::new(width - PADDLE_WIDTH,
+                             paddle_y,
+                             height,
+                             PADDLE_WIDTH,
+                             PADDLE_HEIGHT);
         let ball_x = width / 2 - BALL_RADIUS / 2;
         let ball_y = height / 2 - BALL_RADIUS / 2;
-        let ball = Ball::new(ball_x, ball_y, BALL_RADIUS, INITIAL_BALL_VX, INITIAL_BALL_VY);
+        let ball = Ball::new(ball_x,
+                             ball_y,
+                             BALL_RADIUS,
+                             INITIAL_BALL_VX,
+                             INITIAL_BALL_VY);
 
-        Game{
+        Game {
             running: true,
             paused: true,
             score: [0, 0],
             court: court,
             players: [p1, p2],
             ball: ball,
-            keymap: KeyPressMap::new()
+            keymap: KeyPressMap::new(),
         }
     }
 
-    pub fn run(&mut self, sdl_context: Sdl) {
-        let mut event_pump = sdl_context.event_pump();
-        let window = match Window::new(&sdl_context, "PWONG", WindowPos::PosCentered, WindowPos::PosCentered, self.court.width, self.court.height, RESIZABLE) {
-            Ok(window) => window,
-            Err(err) => panic!("failed to create window: {}", err)
-        };
-        let mut renderer = match Renderer::from_window(window, RenderDriverIndex::Auto, SOFTWARE) {
-            Ok(renderer) => renderer,
-            Err(err) => panic!("failed to create renderer: {}", err)
-        };
+    pub fn run(&mut self) {
+        let sdl_context = sdl2::init().unwrap();
+        let video_subsystem = sdl_context.video().unwrap();
+        let window = video_subsystem
+            .window("Window", 800, 600)
+            .opengl()
+            .position_centered()
+            .resizable()
+            .build()
+            .unwrap();
+        let mut canvas = window
+            .into_canvas()
+            .index(find_sdl_gl_driver().unwrap())
+            .build()
+            .unwrap();
+
+        gl::load_with(|name| video_subsystem.gl_get_proc_address(name) as *const _);
+        canvas.window().gl_set_context_to_current();
+
+        let mut event_pump = sdl_context.event_pump().unwrap();
+
         while self.running {
             self.capture_events(&mut event_pump);
             self.move_objects();
-            self.wipe(&mut renderer);
-            self.draw(&mut renderer);
+            self.wipe(&mut canvas);
+            self.draw(&mut canvas);
             self.check_for_score();
             thread::sleep_ms(17);
         }
@@ -96,46 +124,50 @@ impl Game {
     pub fn capture_events(&mut self, event_pump: &mut EventPump) {
         for event in event_pump.poll_iter() {
             match event {
-                Event::Quit {..} | Event::KeyDown { keycode: KeyCode::Escape, .. } => self.quit(),
-                Event::KeyDown{ keycode: KeyCode::Space, .. } => self.pause(),
-                Event::KeyDown{ keycode: KeyCode::R, .. } => self.reset(),
-                Event::KeyDown{ keycode, .. } => self.keymap.press(keycode),
-                Event::KeyUp{ keycode, .. } => self.keymap.release(keycode),
-                Event::Window { win_event_id: WindowEventId::Resized, data1, data2, .. } => self.handle_resize(data1, data2),
+                Event::Quit { .. } |
+                Event::KeyDown { keycode: Some(Keycode::Escape), .. } => self.quit(),
+                Event::KeyDown { keycode: Some(Keycode::Space), .. } => self.pause(),
+                Event::KeyDown { keycode: Some(Keycode::R), .. } => self.reset(),
+                Event::KeyDown { keycode, .. } => self.keymap.press(keycode),
+                Event::KeyUp { keycode, .. } => self.keymap.release(keycode),
+                Event::Window { win_event: WindowEvent::Resized(data1, data2), .. } => {
+                    self.handle_resize(data1, data2)
+                }
                 _ => {}
             }
         }
     }
 
     pub fn move_objects(&mut self) {
-        if ! self.paused {
-            let p1_key = self.keymap.last_pressed(&[KeyCode::A, KeyCode::Z]);
+        if !self.paused {
+            let p1_key = self.keymap.last_pressed(&[Keycode::A, Keycode::Z]);
             self.players[0].direction = match p1_key {
-                KeyCode::A => PaddleDirection::UP,
-                KeyCode::Z => PaddleDirection::DOWN,
-                _ => PaddleDirection::NONE
+                Keycode::A => PaddleDirection::UP,
+                Keycode::Z => PaddleDirection::DOWN,
+                _ => PaddleDirection::NONE,
             };
-            let p2_key = self.keymap.last_pressed(&[KeyCode::Quote, KeyCode::Slash]);
+            let p2_key = self.keymap.last_pressed(&[Keycode::Quote, Keycode::Slash]);
             self.players[1].direction = match p2_key {
-                KeyCode::Quote => PaddleDirection::UP,
-                KeyCode::Slash => PaddleDirection::DOWN,
-                _ => PaddleDirection::NONE
+                Keycode::Quote => PaddleDirection::UP,
+                Keycode::Slash => PaddleDirection::DOWN,
+                _ => PaddleDirection::NONE,
             };
             for player in self.players.iter_mut() {
                 player.update()
             }
 
-            self.ball.update(&self.players[0], &self.players[1], self.court.height);
+            self.ball
+                .update(&self.players[0], &self.players[1], self.court.height);
         }
     }
 
-    pub fn wipe(&mut self, renderer: &mut Renderer) {
+    pub fn wipe(&mut self, renderer: &mut Canvas<Window>) {
         let mut drawer = renderer.drawer();
         drawer.set_draw_color(Color::RGB(0, 0, 0));
         drawer.clear();
     }
 
-    pub fn draw(&mut self, renderer: &mut Renderer) {
+    pub fn draw(&mut self, renderer: &mut Canvas<Window>) {
         let mut drawer = renderer.drawer();
         drawer.set_draw_color(Color::RGB(255, 157, 0));
         for player in self.players.iter_mut() {
@@ -177,13 +209,13 @@ impl Game {
     }
 
     pub fn reset(&mut self) {
-        self.score = [0,0];
+        self.score = [0, 0];
         self.reset_entities();
         self.paused = true;
     }
 
     pub fn pause(&mut self) {
-        self.paused = ! self.paused;
+        self.paused = !self.paused;
     }
 
     pub fn quit(&mut self) {

--- a/src/entities/game.rs
+++ b/src/entities/game.rs
@@ -128,8 +128,8 @@ impl Game {
                 Event::KeyDown { keycode: Some(Keycode::Escape), .. } => self.quit(),
                 Event::KeyDown { keycode: Some(Keycode::Space), .. } => self.pause(),
                 Event::KeyDown { keycode: Some(Keycode::R), .. } => self.reset(),
-                Event::KeyDown { keycode, .. } => self.keymap.press(keycode),
-                Event::KeyUp { keycode, .. } => self.keymap.release(keycode),
+                Event::KeyDown { keycode, .. } => self.keymap.press(keycode.unwrap()),
+                Event::KeyUp { keycode, .. } => self.keymap.release(keycode.unwrap()),
                 Event::Window { win_event: WindowEvent::Resized(data1, data2), .. } => {
                     self.handle_resize(data1, data2)
                 }
@@ -161,21 +161,19 @@ impl Game {
         }
     }
 
-    pub fn wipe(&mut self, renderer: &mut Canvas<Window>) {
-        let mut drawer = renderer.drawer();
-        drawer.set_draw_color(Color::RGB(0, 0, 0));
-        drawer.clear();
+    pub fn wipe(&mut self, canvas: &mut Canvas<Window>) {
+        canvas.set_draw_color(Color::RGB(0, 0, 0));
+        canvas.clear();
     }
 
-    pub fn draw(&mut self, renderer: &mut Canvas<Window>) {
-        let mut drawer = renderer.drawer();
-        drawer.set_draw_color(Color::RGB(255, 157, 0));
+    pub fn draw(&mut self, canvas: &mut Canvas<Window>) {
+        canvas.set_draw_color(Color::RGB(255, 157, 0));
         for player in self.players.iter_mut() {
-            drawer.draw_rect(player.get_rect());
+            canvas.draw_rect(player.get_rect());
         }
         let points = self.ball.get_points();
-        drawer.draw_points(&points[..]);
-        drawer.present();
+        canvas.draw_points(&points[..]);
+        canvas.present();
     }
 
     // In lieu of a more structured player type and event system, monitor the x coordinate of the ball, score for the appropriate player

--- a/src/entities/game.rs
+++ b/src/entities/game.rs
@@ -141,13 +141,15 @@ impl Game {
     pub fn move_objects(&mut self) {
         if !self.paused {
             let p1_key = self.keymap.last_pressed(&[Keycode::A, Keycode::Z]);
-
+                
             if p1_key.is_some() {
                 self.players[0].direction = match p1_key.unwrap() {
                     Keycode::A => PaddleDirection::UP,
                     Keycode::Z => PaddleDirection::DOWN,
                     _ => PaddleDirection::NONE,
                 };
+            } else {
+                self.players[0].direction = PaddleDirection::NONE;
             }
 
             let p2_key = self.keymap.last_pressed(&[Keycode::Quote, Keycode::Slash]);
@@ -158,6 +160,8 @@ impl Game {
                     Keycode::Slash => PaddleDirection::DOWN,
                     _ => PaddleDirection::NONE,
                 };
+            } else {
+                self.players[1].direction = PaddleDirection::NONE;
             }
 
             for player in self.players.iter_mut() {

--- a/src/entities/game.rs
+++ b/src/entities/game.rs
@@ -140,29 +140,28 @@ impl Game {
 
     pub fn move_objects(&mut self) {
         if !self.paused {
-            let p1_key = self.keymap.last_pressed(&[Keycode::A, Keycode::Z]);
-                
-            if p1_key.is_some() {
-                self.players[0].direction = match p1_key.unwrap() {
-                    Keycode::A => PaddleDirection::UP,
-                    Keycode::Z => PaddleDirection::DOWN,
-                    _ => PaddleDirection::NONE,
-                };
-            } else {
-                self.players[0].direction = PaddleDirection::NONE;
-            }
 
-            let p2_key = self.keymap.last_pressed(&[Keycode::Quote, Keycode::Slash]);
+            match self.keymap.last_pressed(&[Keycode::A, Keycode::Z]) {
+                Some(key) => {
+                    self.players[0].direction = match key {
+                        Keycode::A => PaddleDirection::UP,
+                        Keycode::Z => PaddleDirection::DOWN,
+                        _ => PaddleDirection::NONE
+                    };
+                },
+                None => self.players[0].direction = PaddleDirection::NONE
+            };
 
-            if p2_key.is_some() {
-                self.players[1].direction = match p2_key.unwrap() {
-                    Keycode::Quote => PaddleDirection::UP,
-                    Keycode::Slash => PaddleDirection::DOWN,
-                    _ => PaddleDirection::NONE,
-                };
-            } else {
-                self.players[1].direction = PaddleDirection::NONE;
-            }
+            match self.keymap.last_pressed(&[Keycode::Quote, Keycode::Slash]) {
+                Some(key) => {
+                    self.players[1].direction = match key {
+                        Keycode::Quote => PaddleDirection::UP,
+                        Keycode::Slash => PaddleDirection::DOWN,
+                        _ => PaddleDirection::NONE
+                    };
+                },
+                None => self.players[1].direction = PaddleDirection::NONE
+            };
 
             for player in self.players.iter_mut() {
                 player.update()

--- a/src/entities/game.rs
+++ b/src/entities/game.rs
@@ -143,10 +143,10 @@ impl Game {
 
             match self.keymap.last_pressed(&[Keycode::A, Keycode::Z]) {
                 Some(key) => {
-                    self.players[0].direction = match key {
-                        Keycode::A => PaddleDirection::UP,
-                        Keycode::Z => PaddleDirection::DOWN,
-                        _ => PaddleDirection::NONE
+                    match key {
+                        Keycode::A => self.players[0].direction = PaddleDirection::UP,
+                        Keycode::Z => self.players[0].direction = PaddleDirection::DOWN,
+                        _ => {}
                     };
                 },
                 None => self.players[0].direction = PaddleDirection::NONE
@@ -154,10 +154,10 @@ impl Game {
 
             match self.keymap.last_pressed(&[Keycode::Quote, Keycode::Slash]) {
                 Some(key) => {
-                    self.players[1].direction = match key {
-                        Keycode::Quote => PaddleDirection::UP,
-                        Keycode::Slash => PaddleDirection::DOWN,
-                        _ => PaddleDirection::NONE
+                    match key {
+                        Keycode::Quote => self.players[1].direction = PaddleDirection::UP,
+                        Keycode::Slash => self.players[1].direction = PaddleDirection::DOWN,
+                        _ => {}
                     };
                 },
                 None => self.players[1].direction = PaddleDirection::NONE

--- a/src/entities/keymap.rs
+++ b/src/entities/keymap.rs
@@ -19,9 +19,7 @@ impl KeyPressMap {
     }
 
     fn key_to_index(&mut self, key: Keycode) -> usize {
-        let mut hasher = DefaultHasher::new();
-        key.hash(&mut hasher);
-        return hasher.finish() as usize;
+        return key as usize;
     }
 
     pub fn press(&mut self, key: Keycode) {

--- a/src/entities/keymap.rs
+++ b/src/entities/keymap.rs
@@ -2,40 +2,40 @@ extern crate num;
 extern crate sdl2;
 extern crate time;
 
-use self::sdl2::keycode::KeyCode;
+use self::sdl2::keyboard::Keycode;
 use self::num::ToPrimitive;
 
-static KEY_COUNT : usize = 235;
+static KEY_COUNT: usize = 235;
 
 pub struct KeyPressMap {
-    pub pressed: [u64; 235]
+    pub pressed: [u64; 235],
 }
 
 impl KeyPressMap {
     pub fn new() -> KeyPressMap {
-        KeyPressMap{pressed: [0u64; 235]}
+        KeyPressMap { pressed: [0u64; 235] }
     }
 
-    fn key_to_index(&mut self, key: KeyCode) -> usize {
-        return key.to_isize().unwrap() as usize
+    fn key_to_index(&mut self, key: Keycode) -> usize {
+        return key.to_isize().unwrap() as usize;
     }
 
-    pub fn press(&mut self, key: KeyCode) {
+    pub fn press(&mut self, key: Keycode) {
         let i = self.key_to_index(key);
         if i <= KEY_COUNT {
             self.pressed[i] = time::precise_time_ns();
         }
     }
 
-    pub fn release(&mut self, key: KeyCode) {
+    pub fn release(&mut self, key: Keycode) {
         let i = self.key_to_index(key);
         if i <= KEY_COUNT {
             self.pressed[i] = 0u64;
         }
     }
 
-    pub fn last_pressed(&mut self, keys: &[KeyCode]) -> KeyCode {
-        let mut last_key = KeyCode::Unknown;
+    pub fn last_pressed(&mut self, keys: &[Keycode]) -> Keycode {
+        let mut last_key = Keycode::Unknown;
         let mut last_time = 0u64;
         for key in keys {
             let i = self.key_to_index(*key);
@@ -47,36 +47,36 @@ impl KeyPressMap {
         return last_key;
     }
 
-    pub fn is_pressed(&mut self, key: KeyCode) -> bool {
+    pub fn is_pressed(&mut self, key: Keycode) -> bool {
         let i = self.key_to_index(key);
         if self.pressed[i] > 0u64 {
-            return true
+            return true;
         }
-        return false
+        return false;
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::sdl2::keycode::KeyCode;
+    use super::sdl2::keyboard::Keycode;
 
     #[test]
     fn test_key_mapping() {
         let mut map = KeyPressMap::new();
-        map.press(KeyCode::A);
-        assert!(map.is_pressed(KeyCode::A) == true);
-        assert!(map.is_pressed(KeyCode::B) == false);
-        assert!(map.last_pressed(&[KeyCode::A, KeyCode::B]) == KeyCode::A);
+        map.press(Keycode::A);
+        assert!(map.is_pressed(Keycode::A) == true);
+        assert!(map.is_pressed(Keycode::B) == false);
+        assert!(map.last_pressed(&[Keycode::A, Keycode::B]) == Keycode::A);
 
-        map.press(KeyCode::B);
-        assert!(map.is_pressed(KeyCode::A) == true);
-        assert!(map.is_pressed(KeyCode::B) == true);
-        assert!(map.last_pressed(&[KeyCode::A, KeyCode::B]) == KeyCode::B);
+        map.press(Keycode::B);
+        assert!(map.is_pressed(Keycode::A) == true);
+        assert!(map.is_pressed(Keycode::B) == true);
+        assert!(map.last_pressed(&[Keycode::A, KeyCode::B]) == Keycode::B);
 
-        map.release(KeyCode::A);
-        assert!(map.is_pressed(KeyCode::A) == false);
-        assert!(map.is_pressed(KeyCode::B) == true);
-        assert!(map.last_pressed(&[KeyCode::A, KeyCode::B]) == KeyCode::B);
+        map.release(Keycode::A);
+        assert!(map.is_pressed(Keycode::A) == false);
+        assert!(map.is_pressed(Keycode::B) == true);
+        assert!(map.last_pressed(&[Keycode::A, Keycode::B]) == Keycode::B);
     }
 }

--- a/src/entities/keymap.rs
+++ b/src/entities/keymap.rs
@@ -38,16 +38,18 @@ impl KeyPressMap {
         }
     }
 
-    pub fn last_pressed(&mut self, keys: &[Keycode]) -> Keycode {
-        let mut last_key = Keycode::Unknown;
+    pub fn last_pressed(&mut self, keys: &[Keycode]) -> Option<Keycode> {
+        let mut last_key: Option<Keycode> = None;
         let mut last_time = 0u64;
+
         for key in keys {
             let i = self.key_to_index(*key);
             if self.pressed[i] > last_time {
-                last_key = *key;
+                last_key = Some(*key);
                 last_time = self.pressed[i];
             }
         }
+
         return last_key;
     }
 
@@ -71,16 +73,25 @@ mod tests {
         map.press(Keycode::A);
         assert!(map.is_pressed(Keycode::A) == true);
         assert!(map.is_pressed(Keycode::B) == false);
-        assert!(map.last_pressed(&[Keycode::A, Keycode::B]) == Keycode::A);
+        match map.last_pressed(&[Keycode::A, Keycode::B]) {
+            Some(key) => assert!(key == Keycode::A),
+            None => assert!(false)
+        }
 
         map.press(Keycode::B);
         assert!(map.is_pressed(Keycode::A) == true);
         assert!(map.is_pressed(Keycode::B) == true);
-        assert!(map.last_pressed(&[Keycode::A, KeyCode::B]) == Keycode::B);
+        match map.last_pressed(&[Keycode::A, Keycode::B]) {
+            Some(key) => assert!(key == Keycode::B),
+            None => assert!(false)
+        }
 
         map.release(Keycode::A);
         assert!(map.is_pressed(Keycode::A) == false);
         assert!(map.is_pressed(Keycode::B) == true);
-        assert!(map.last_pressed(&[Keycode::A, Keycode::B]) == Keycode::B);
+        match map.last_pressed(&[Keycode::A, Keycode::B]) {
+            Some(key) => assert!(key == Keycode::B),
+            None => assert!(false)
+        }
     }
 }

--- a/src/entities/keymap.rs
+++ b/src/entities/keymap.rs
@@ -2,22 +2,26 @@ extern crate num;
 extern crate sdl2;
 extern crate time;
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use self::sdl2::keyboard::Keycode;
 use self::num::ToPrimitive;
 
 static KEY_COUNT: usize = 235;
 
 pub struct KeyPressMap {
-    pub pressed: [u64; 235],
+    pub pressed: [u64; 235]
 }
 
 impl KeyPressMap {
     pub fn new() -> KeyPressMap {
-        KeyPressMap { pressed: [0u64; 235] }
+        KeyPressMap{pressed: [0u64; 235]}
     }
 
     fn key_to_index(&mut self, key: Keycode) -> usize {
-        return key.to_isize().unwrap() as usize;
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        return hasher.finish() as usize;
     }
 
     pub fn press(&mut self, key: Keycode) {

--- a/src/entities/paddle.rs
+++ b/src/entities/paddle.rs
@@ -5,33 +5,33 @@ use entities::bounds::BoundingBox;
 use self::sdl2::rect::Rect;
 
 
-static DEFAULT_VELOCITY : f32 = 5f32;
-static MAX_VELOCITY : f32 = 40f32;
-static MULTIPLIER_UP : f32 = -1f32;
-static MULTIPLIER_DOWN : f32 = 1f32;
-static ACCELERATION_FACTOR : f32 = 1.05;
+static DEFAULT_VELOCITY: f32 = 5f32;
+static MAX_VELOCITY: f32 = 40f32;
+static MULTIPLIER_UP: f32 = -1f32;
+static MULTIPLIER_DOWN: f32 = 1f32;
+static ACCELERATION_FACTOR: f32 = 1.05;
 
 pub enum PaddleDirection {
     UP,
     DOWN,
-    NONE
+    NONE,
 }
 
 pub struct Paddle {
-	pub x: i32,
-	pub y: i32,
-	pub max_y: i32,
-	pub width: i32,
-	pub height: i32,
+    pub x: i32,
+    pub y: i32,
+    pub max_y: i32,
+    pub width: i32,
+    pub height: i32,
     pub velocity: f32,
     pub direction: PaddleDirection,
     pub multiplier: f32,
-    pub bounding_box: BoundingBox
+    pub bounding_box: BoundingBox,
 }
 
 impl Paddle {
-	pub fn new(x: i32, y: i32, max_y: i32, width: i32, height: i32) -> Paddle {
-		Paddle{
+    pub fn new(x: i32, y: i32, max_y: i32, width: i32, height: i32) -> Paddle {
+        Paddle {
             x: x,
             y: y,
             max_y: max_y,
@@ -40,19 +40,19 @@ impl Paddle {
             velocity: DEFAULT_VELOCITY,
             direction: PaddleDirection::NONE,
             multiplier: 0f32,
-            bounding_box: BoundingBox::new(x, y, width, height)
+            bounding_box: BoundingBox::new(x, y, width, height),
         }
-	}
+    }
 
     pub fn get_rect(&mut self) -> Rect {
-        return Rect::new(self.x, self.y, self.width, self.height)
+        return Rect::new(self.x, self.y, self.width, self.height);
     }
 
     pub fn update(&mut self) {
         let multiplier = match self.direction {
             PaddleDirection::UP => MULTIPLIER_UP,
             PaddleDirection::DOWN => MULTIPLIER_DOWN,
-            PaddleDirection::NONE => 0f32
+            PaddleDirection::NONE => 0f32,
         };
 
         if (self.multiplier < 0f32) != (multiplier < 0f32) || multiplier == 0f32 {
@@ -64,18 +64,15 @@ impl Paddle {
         let new_y = self.y + (multiplier * self.velocity) as i32;
         if new_y < 0 {
             self.y = 0;
-        }
-        else if new_y > self.max_y - self.height {
+        } else if new_y > self.max_y - self.height {
             self.y = self.max_y - self.height;
-        }
-        else {
+        } else {
             self.y = new_y;
 
             let new_velocity = self.velocity * ACCELERATION_FACTOR;
             if new_velocity <= MAX_VELOCITY {
                 self.velocity = new_velocity;
-            }
-            else {
+            } else {
                 self.velocity = MAX_VELOCITY;
             }
         }
@@ -87,12 +84,12 @@ impl Paddle {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn test_movement_and_acceleration() {
-		let mut p1 = Paddle::new(0, 40, 800, 40, 100);
-		assert!(p1.velocity > 0f32);
+    #[test]
+    fn test_movement_and_acceleration() {
+        let mut p1 = Paddle::new(0, 40, 800, 40, 100);
+        assert!(p1.velocity > 0f32);
 
         let mut last_y = p1.y;
         let mut last_vel = p1.velocity;
@@ -133,5 +130,5 @@ mod tests {
         p1.move_it();
         assert!(p1.velocity > 5f32);
         assert!(p1.y < last_y);
-	}
+    }
 }

--- a/src/entities/paddle.rs
+++ b/src/entities/paddle.rs
@@ -45,7 +45,7 @@ impl Paddle {
     }
 
     pub fn get_rect(&mut self) -> Rect {
-        return Rect::new(self.x, self.y, self.width, self.height);
+        return Rect::new(self.x, self.y, self.width as u32, self.height as u32);
     }
 
     pub fn update(&mut self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,10 @@ extern crate pwong;
 
 use pwong::entities::game::Game;
 
-static INITIAL_HEIGHT: u32 = 800;
-static INITIAL_WIDTH: u32 = 1200;
+static INITIAL_HEIGHT: i32 = 800;
+static INITIAL_WIDTH: i32 = 1200;
 
 pub fn main() {
-    let sdl_context = sdl2::init(sdl2::INIT_VIDEO).unwrap();
-
     let mut game = Game::new(INITIAL_WIDTH, INITIAL_HEIGHT);
-    game.run(sdl_context);
+    game.run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ extern crate pwong;
 
 use pwong::entities::game::Game;
 
-static INITIAL_HEIGHT : i32 = 800;
-static INITIAL_WIDTH : i32 = 1200;
+static INITIAL_HEIGHT: u32 = 800;
+static INITIAL_WIDTH: u32 = 1200;
 
 pub fn main() {
     let sdl_context = sdl2::init(sdl2::INIT_VIDEO).unwrap();


### PR DESCRIPTION
All of the changes herein are to support the latest version of Rust and the SDL2 bindings. The initialization process the window is entirely different and some keyboard event handling had to be tweaked. The `last_pressed` method of the Keymap now returns an option type since the return value is either a key we're interested in or something we're not (`None`). We should update the API for dealing with this in the game's `move_objects` method but my goal was to just get the game running with the newer and more stable APIs. 