### PR TITLE
Add theme and textbox objects

### DIFF
--- a/src/entities/game.rs
+++ b/src/entities/game.rs
@@ -261,9 +261,10 @@ impl<'ttf, 'a> Game<'ttf, 'a> {
         }
 
         for (i, score) in self.score.iter().enumerate() {
-            let score_box = TextBox::new(self.theme, &score.to_string(), self.court);
+            let score_str = &score.to_string();
+            let mut score_box = TextBox::new(&self.theme, score_str, &self.court);
             let x_offset = if i == 0 { margin } else { 0 - margin };
-            score_box.render(&mut canvas, x_offset, margin);
+            score_box.render(canvas, x_offset, margin);
         }
 
         canvas.present();

--- a/src/entities/game.rs
+++ b/src/entities/game.rs
@@ -5,6 +5,9 @@ use super::ball::Ball;
 use super::court::Court;
 use super::keymap::KeyPressMap;
 use super::paddle::{Paddle, PaddleDirection};
+use super::theme::Theme;
+use super::textbox::TextBox;
+
 use crate::audio;
 
 use self::sdl2::EventPump;
@@ -12,12 +15,8 @@ use self::sdl2::event::{Event, WindowEvent};
 use self::sdl2::keyboard::Keycode;
 use self::sdl2::mixer;
 use self::sdl2::pixels::Color;
-use self::sdl2::rect::Rect;
 use self::sdl2::render::Canvas;
-use self::sdl2::rwops::RWops;
-use self::sdl2::video::{Window};
-use self::sdl2::render::TextureQuery;
-
+use self::sdl2::video::Window;
 
 use std::env;
 use std::thread;
@@ -49,6 +48,7 @@ pub struct Game<'a> {
     audio_player: audio::player::Player<'a>,
     sdl_context: self::sdl2::Sdl,
     video_subsystem: self::sdl2::VideoSubsystem,
+    theme: Theme<'a>,
 }
 
 impl<'a> Game<'a> {
@@ -93,6 +93,19 @@ impl<'a> Game<'a> {
             event_subsystem.clone(),
         );
 
+        let ttf_context = sdl2::ttf::init().map_err(|e| e.to_string()).unwrap();
+
+        let color = Color::RGB(255, 157, 0);
+        let font_size = 36;
+        let font_bytes = include_bytes!("../OpenSans-Regular.ttf");
+
+        let theme = Theme::new(
+            color,
+            font_bytes,
+            font_size,
+            &ttf_context,
+        );
+
         Game {
             running: true,
             paused: true,
@@ -104,6 +117,7 @@ impl<'a> Game<'a> {
             audio_player: audio_player,
             sdl_context: sdl_context,
             video_subsystem: video_subsystem,
+            theme: theme,
         }
     }
 
@@ -231,11 +245,9 @@ impl<'a> Game<'a> {
     }
 
     pub fn draw(&mut self, canvas: &mut Canvas<Window>) {
-        let color = Color::RGB(255, 157, 0);
-        let font_size = 36;
         let margin = 20i32;
 
-        canvas.set_draw_color(color);
+        canvas.set_draw_color(self.theme.color);
         for player in self.players.iter_mut() {
             match canvas.draw_rect(player.get_rect()) {
                 Err(why) => panic!("{:?}", why),
@@ -248,26 +260,10 @@ impl<'a> Game<'a> {
             Ok(_) => {}
         }
 
-        let texture_creator = canvas.texture_creator();
-
-        let ttf_bytes = include_bytes!("../OpenSans-Regular.ttf");
-        let ttf_rwops = RWops::from_bytes(ttf_bytes).unwrap();
-
-        let ttf_context = sdl2::ttf::init().map_err(|e| e.to_string()).unwrap();
-        let sdl_font = ttf_context.load_font_from_rwops(ttf_rwops, font_size).unwrap();
-
         for (i, score) in self.score.iter().enumerate() {
-            let surface = sdl_font.render(&score.to_string())
-                .blended(color).map_err(|e| e.to_string()).unwrap();
-            let texture = texture_creator.create_texture_from_surface(&surface)
-                .map_err(|e| e.to_string()).unwrap();
-
-            let TextureQuery { width, height, .. } = texture.query();
-
-            let x = if i == 0 { margin } else { self.court.width - width as i32 - margin };
-            let score_box = Rect::new(x, margin, width, height);
-    
-            canvas.copy(&texture, None, Some(score_box)).unwrap();
+            let score_box = TextBox::new(self.theme, &score.to_string(), self.court);
+            let x_offset = if i == 0 { margin } else { 0 - margin };
+            score_box.render(&mut canvas, x_offset, margin);
         }
 
         canvas.present();

--- a/src/entities/game.rs
+++ b/src/entities/game.rs
@@ -37,7 +37,7 @@ fn find_sdl_gl_driver() -> Option<u32> {
     None
 }
 
-pub struct Game<'a> {
+pub struct Game<'ttf, 'a> {
     running: bool,
     paused: bool,
     score: [i32; 2],
@@ -48,11 +48,11 @@ pub struct Game<'a> {
     audio_player: audio::player::Player<'a>,
     sdl_context: self::sdl2::Sdl,
     video_subsystem: self::sdl2::VideoSubsystem,
-    theme: Theme<'a>,
+    theme: Theme<'ttf, 'a>,
 }
 
-impl<'a> Game<'a> {
-    pub fn new(width: i32, height: i32) -> Game<'a> {
+impl<'ttf, 'a> Game<'ttf, 'a> {
+    pub fn new(ttf_context: &'ttf sdl2::ttf::Sdl2TtfContext, width: i32, height: i32) -> Game<'ttf, 'a> {
         let sdl_context = sdl2::init().unwrap();
         // SDL sub-systems.
         let event_subsystem = sdl_context.event().unwrap();
@@ -93,7 +93,7 @@ impl<'a> Game<'a> {
             event_subsystem.clone(),
         );
 
-        let ttf_context = sdl2::ttf::init().map_err(|e| e.to_string()).unwrap();
+        //let ttf_context = sdl2::ttf::init().map_err(|e| e.to_string()).unwrap();
 
         let color = Color::RGB(255, 157, 0);
         let font_size = 36;
@@ -103,7 +103,7 @@ impl<'a> Game<'a> {
             color,
             font_bytes,
             font_size,
-            &ttf_context,
+            ttf_context,
         );
 
         Game {

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -4,3 +4,5 @@ pub mod court;
 pub mod game;
 pub mod keymap;
 pub mod paddle;
+pub mod textbox;
+pub mod theme;

--- a/src/entities/textbox.rs
+++ b/src/entities/textbox.rs
@@ -8,14 +8,14 @@ use self::sdl2::render::Canvas;
 use self::sdl2::render::TextureQuery;
 use self::sdl2::video::Window;
 
-pub struct TextBox<'a> {
-    pub theme: Theme<'a>,
+pub struct TextBox<'ttf, 'a> {
+    pub theme: Theme<'ttf, 'a>,
     pub content: &'a str,
     pub court: Court,
 }
 
-impl<'a> TextBox<'a> {
-    pub fn new(theme: Theme<'a>, content: &'a str, court: Court) -> TextBox<'a> {
+impl<'ttf, 'a> TextBox<'ttf, 'a> {
+    pub fn new(theme: Theme<'ttf, 'a>, content: &'a str, court: Court) -> TextBox<'ttf, 'a> {
         TextBox {
             theme: theme,
             content: content,

--- a/src/entities/textbox.rs
+++ b/src/entities/textbox.rs
@@ -1,0 +1,42 @@
+extern crate sdl2;
+
+use super::court::Court;
+use super::theme::Theme;
+
+use self::sdl2::rect::Rect;
+use self::sdl2::render::Canvas;
+use self::sdl2::render::TextureQuery;
+use self::sdl2::video::Window;
+
+pub struct TextBox<'a> {
+    pub theme: Theme<'a>,
+    pub content: &'a str,
+    pub court: Court,
+}
+
+impl<'a> TextBox<'a> {
+    pub fn new(theme: Theme<'a>, content: &'a str, court: Court) -> TextBox<'a> {
+        TextBox {
+            theme: theme,
+            content: content,
+            court: court,
+        }
+    }
+
+    pub fn render(&mut self, canvas: &mut Canvas<Window>, x_offset: i32, y_offset: i32) {
+        let texture_creator = canvas.texture_creator();
+
+        let surface = self.theme.font.render(&self.content)
+            .blended(self.theme.color).map_err(|e| e.to_string()).unwrap();
+        let texture = texture_creator.create_texture_from_surface(&surface)
+            .map_err(|e| e.to_string()).unwrap();
+
+        let TextureQuery { width, height, .. } = texture.query();
+
+        let x = if x_offset < 0 { self.court.width + x_offset - width as i32 } else { x_offset };
+        let y = if y_offset < 0 { self.court.height + height as i32 + y_offset - height as i32 } else { y_offset };
+        let text_box = Rect::new(x, y, width, height);
+
+        canvas.copy(&texture, None, Some(text_box)).unwrap();
+    }
+}

--- a/src/entities/textbox.rs
+++ b/src/entities/textbox.rs
@@ -9,15 +9,15 @@ use self::sdl2::render::TextureQuery;
 use self::sdl2::video::Window;
 
 pub struct TextBox<'ttf, 'a> {
-    pub theme: Theme<'ttf, 'a>,
+    pub theme: &'a Theme<'ttf, 'a>,
     pub content: &'a str,
-    pub court: Court,
+    pub court: &'a Court,
 }
 
 impl<'ttf, 'a> TextBox<'ttf, 'a> {
-    pub fn new(theme: Theme<'ttf, 'a>, content: &'a str, court: Court) -> TextBox<'ttf, 'a> {
+    pub fn new(theme: &'a Theme<'ttf, 'a>, content: &'a str, court: &'a Court) -> TextBox<'ttf, 'a> {
         TextBox {
-            theme: theme,
+            theme: &theme,
             content: content,
             court: court,
         }

--- a/src/entities/theme.rs
+++ b/src/entities/theme.rs
@@ -1,0 +1,26 @@
+extern crate sdl2;
+
+use self::sdl2::pixels::Color;
+use self::sdl2::rwops::RWops;
+use self::sdl2::ttf::Font;
+use self::sdl2::ttf::Sdl2TtfContext;
+
+
+pub struct Theme<'a> {
+    pub color: Color,
+    pub font: Font<'a, 'a>,
+    pub font_size: u16,
+}
+
+impl<'a> Theme<'a> {
+    pub fn new(color: Color, font_bytes: &'a[u8], font_size: u16, ttf_context: &'a Sdl2TtfContext) -> Theme<'a> {
+        let ttf_rwops = RWops::from_bytes(font_bytes).unwrap();
+        let font = ttf_context.load_font_from_rwops(ttf_rwops, font_size).unwrap();
+
+        Theme {
+            color: color,
+            font: font,
+            font_size: font_size,
+        }
+    }
+}

--- a/src/entities/theme.rs
+++ b/src/entities/theme.rs
@@ -6,14 +6,14 @@ use self::sdl2::ttf::Font;
 use self::sdl2::ttf::Sdl2TtfContext;
 
 
-pub struct Theme<'a> {
+pub struct Theme<'ttf, 'a> {
     pub color: Color,
-    pub font: Font<'a, 'a>,
+    pub font: Font<'ttf, 'a>,
     pub font_size: u16,
 }
 
-impl<'a> Theme<'a> {
-    pub fn new(color: Color, font_bytes: &'a[u8], font_size: u16, ttf_context: &'a Sdl2TtfContext) -> Theme<'a> {
+impl<'ttf, 'a> Theme<'ttf, 'a> {
+    pub fn new(color: Color, font_bytes: &'a[u8], font_size: u16, ttf_context: &'ttf Sdl2TtfContext) -> Theme<'ttf, 'a> {
         let ttf_rwops = RWops::from_bytes(font_bytes).unwrap();
         let font = ttf_context.load_font_from_rwops(ttf_rwops, font_size).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ static INITIAL_HEIGHT: i32 = 800;
 static INITIAL_WIDTH: i32 = 1200;
 
 pub fn main() {
-    let mut game = Game::new(INITIAL_WIDTH, INITIAL_HEIGHT);
+    let ttf_context = sdl2::ttf::init().unwrap();
+    let mut game = Game::new(&ttf_context, INITIAL_WIDTH, INITIAL_HEIGHT);
     game.run();
 }


### PR DESCRIPTION
Doing a little refactoring to make the textbox bits more reusable so we
can use them for other scenarios besides displaying the scores.

Doesn't quite work yet. The Font object in the Theme object contains a borrowed reference to ttf_context from Game::new, so the lifetime checker whines. 